### PR TITLE
Graphql schema update for filtering user

### DIFF
--- a/analytics/core/query.py
+++ b/analytics/core/query.py
@@ -1,0 +1,73 @@
+def stats_query():
+    return [
+        {
+            "$group": {
+                "_id": {
+                    "username": "$username",
+                    "exerciseType": "$exerciseType"
+                },
+                "totalDuration": {"$sum": "$duration"},
+                "totalDistance": {"$sum": "$distance"},
+                "averagePace": {"$avg": "$pace"},
+                "averageSpeed": {"$avg": "$speed"},
+                "topSpeed": {"$max": "$speed"}
+            }
+        },
+        {
+            "$group": {
+                "_id": "$_id.username",
+                "exercises": {
+                    "$push": {
+                        "exerciseType": "$_id.exerciseType",
+                        "totalDuration": "$totalDuration",
+                        "totalDistance": "$totalDistance",
+                        "averagePace": "$averagePace",
+                        "averageSpeed": "$averageSpeed",
+                        "topSpeed": "$topSpeed"
+                    }
+                }
+            }
+        },
+        {
+            "$project": {
+                "username": "$_id",
+                "exercises": 1,
+                "_id": 0
+            }
+        }
+    ]
+
+
+def stats_by_username_query(username):
+    return [
+        {
+            "$match": {"username": username}
+        },
+        {
+            "$group": {
+                "_id": {
+                    "username": "$username",
+                    "exerciseType": "$exerciseType"
+                },
+                "totalDuration": {"$sum": "$duration"}
+            }
+        },
+        {
+            "$group": {
+                "_id": "$_id.username",
+                "exercises": {
+                    "$push": {
+                        "exerciseType": "$_id.exerciseType",
+                        "totalDuration": "$totalDuration"
+                    }
+                }
+            }
+        },
+        {
+            "$project": {
+                "username": "$_id",
+                "exercises": 1,
+                "_id": 0
+            }
+        }
+    ]

--- a/analytics/core/query.py
+++ b/analytics/core/query.py
@@ -49,7 +49,11 @@ def stats_by_username_query(username):
                     "username": "$username",
                     "exerciseType": "$exerciseType"
                 },
-                "totalDuration": {"$sum": "$duration"}
+                "totalDuration": {"$sum": "$duration"},
+                "totalDistance": {"$sum": "$distance"},
+                "averagePace": {"$avg": "$pace"},
+                "averageSpeed": {"$avg": "$speed"},
+                "topSpeed": {"$max": "$speed"}
             }
         },
         {
@@ -58,7 +62,11 @@ def stats_by_username_query(username):
                 "exercises": {
                     "$push": {
                         "exerciseType": "$_id.exerciseType",
-                        "totalDuration": "$totalDuration"
+                        "totalDuration": "$totalDuration",
+                        "totalDistance": "$totalDistance",
+                        "averagePace": "$averagePace",
+                        "averageSpeed": "$averageSpeed",
+                        "topSpeed": "$topSpeed"
                     }
                 }
             }

--- a/analytics/core/views.py
+++ b/analytics/core/views.py
@@ -109,5 +109,11 @@ def graphql_server():
     success, result = graphql_sync(
         schema, data, context_value={"request": request}, debug=app.debug
     )
-    status_code = 200 if success else 400
-    return jsonify(result), status_code
+    app.logger.info('%s data returned:', result)
+    if success:
+        data = result['data']
+        status_code = 200
+    else:
+        data = result
+        status_code = 400
+    return jsonify(data), status_code

--- a/analytics/readme.md
+++ b/analytics/readme.md
@@ -13,7 +13,7 @@ This is the Analytics microservice for the MLA Fitness tracker app.
 
 ```sh
 cd analytics
-flask run -h localhost -p 5050
+python3 run.py
 ```
 
 #### spin up MongoDB without docker-compose:

--- a/analytics/tests/test_analytics.py
+++ b/analytics/tests/test_analytics.py
@@ -38,8 +38,70 @@ def test_stats_route_respnse_empty_data(client):
     assert len(data['stats']) == 0
 
 
-def test_stats_route_respnse_data(client, mongo):
+def test_stats_route_response_data(client, mongo):
     response = client.get('/stats')
     data = json.loads(response.text)
     # check that the `stats` data recieved is not empty
     assert len(data['stats']) > 0
+
+
+def test_stats_with_user_route(client):
+    response = client.get('/stats/user1')
+    assert response.status_code == 200
+
+
+def test_stats_with_user_route_respnse_empty_data(client):
+    response = client.get('/stats/user1')
+    data = json.loads(response.text)
+    # check that the `stats` data recieved is empty as mongo fixture is not used
+    assert len(data['stats']) == 0
+
+
+def test_stats_with_user_route_respnse_data(client, mongo):
+    for i in range(1, 10):
+        response = client.get(f'/stats/user{i}')
+        data = json.loads(response.text)
+        # check that the `stats` data recieved has one record per user
+        assert len(data['stats']) == 1
+
+
+def test_graphql_get_request(client):
+    response = client.get('/stats/graphql')
+    assert response.status_code == 200
+
+
+def test_graphql_post_request_get_usernames(client, mongo):
+    response = client.post(
+        '/stats/graphql',
+        json={"query": "query{stats{username}}"}
+    )
+    data = json.loads(response.data)
+    assert len(data) == 1
+    assert len(data['stats']) == 9
+    assert response.status_code == 200
+
+
+def test_graphql_post_request_get_exercises(client, mongo):
+    response = client.post(
+        '/stats/graphql',
+        json={"query": "query{stats{ exercises {exerciseType totalDuration} }}"}
+    )
+    data = json.loads(response.data)
+    assert len(data) == 1
+    # testing there are exercises data
+    assert len(data['stats'][0]['exercises']) >= 1
+    assert response.status_code == 200
+
+
+def test_graphql_post_request_get_filtered_exercises(client, mongo):
+    for i in range(1, 10):
+        response = client.post(
+            '/stats/graphql',
+            json={"query": "query{stats: statsByUsername(username:" +
+                  f"\"user{i}\""+"){ exercises {exerciseType } }}"}
+        )
+        data = json.loads(response.data)
+        assert len(data) == 1
+        # testing there are exercises data
+        assert len(data['stats'][0]['exercises']) >= 1
+        assert response.status_code == 200

--- a/frontend/src/components/statistics.js
+++ b/frontend/src/components/statistics.js
@@ -20,9 +20,20 @@ const Statistics = ({ currentUser }) => {
   const [loading, setLoading] = useState(true);
 
   useEffect(() => {
-    const fetchData = async () => {
+    const fetchGraphQLData = async () => {
       try {
-        const response = await axios.get(`${config.apiUrl}/stats/${currentUser}`);
+        const payload = {
+          query: `
+          {
+            stats: statsByUsername(username: "${currentUser}") { 
+              exercises { 
+                exerciseType 
+                totalDuration 
+              }
+            }
+          }`
+        };
+        const response = await axios.post(`${config.apiUrl}/stats/graphql`, payload);
         setExercisesData(response.data.stats[0].exercises);
         setLoading(false);
       } catch (error) {
@@ -31,7 +42,7 @@ const Statistics = ({ currentUser }) => {
       }
     };
 
-    fetchData();
+    fetchGraphQLData();
   }, [currentUser]);
 
   const renderActiveShape = (props, data, dataType) => {

--- a/frontend/src/components/statistics.js
+++ b/frontend/src/components/statistics.js
@@ -29,6 +29,10 @@ const Statistics = ({ currentUser }) => {
               exercises { 
                 exerciseType 
                 totalDuration 
+                totalDistance
+                averagePace
+                averageSpeed
+                topSpeed
               }
             }
           }`

--- a/frontend/src/components/statistics.js
+++ b/frontend/src/components/statistics.js
@@ -110,7 +110,7 @@ const Statistics = ({ currentUser }) => {
           <ResponsiveContainer width="50%" height={400}>
             <PieChart>
               <text x="50%" y="20" textAnchor="middle" dominantBaseline="middle" className="chart-heading">
-                Total Duration for Exercises 
+                Total Duration for Exercises
               </text>
               <Pie
                 activeIndex={activeDurationIndex}
@@ -179,7 +179,7 @@ const Statistics = ({ currentUser }) => {
                   </div>
                   <Group mt="lg" >
                     <div >
-                      <MText className='label'>{entry.averagePace !== null ?
+                      <MText className='label'>{entry.averagePace != null ?
                         <span>{entry.averagePace.toFixed(2)} <span className="unit">min/km</span></span>
                         : 'N/A'}
                       </MText>
@@ -188,7 +188,7 @@ const Statistics = ({ currentUser }) => {
                       </MText>
                     </div>
                     <div className="average-speed">
-                      <MText className='label'>{entry.averageSpeed !== null ?
+                      <MText className='label'>{entry.averageSpeed != null ?
                         <span>{entry.averageSpeed.toFixed(2)} <span className="unit">km/hr</span></span>
                         : 'N/A'}
                       </MText>


### PR DESCRIPTION
Updated Graph QL schema to have a filter based on `username` and added resolver to handle the username. 
Also, changed `statistics.js` in `frontend` service to call graphql endpoint `/stats/graphql`.

Additional work:
- refactored `view.py` and `gql_schema.py` and moved reusable code into `query.py`.
- changes to documentation to run flask app
- tests for rest and graphql endpoints using test data